### PR TITLE
Generating Rust scaffolding code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
+uniffi = "0.21.0"
+uniffi_macros = "0.21.0"
+
+[build-dependencies]
+uniffi_build = {version = "0.21.0", features = [ "builtin-bindgen" ]}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi_build::generate_scaffolding("./src/calc.udl").unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,5 @@ pub fn mul(a: i64, b: i64) -> i64 {
 pub fn div(a: i64, b: i64) -> i64 {
     a / b
 }
+
+uniffi_macros::include_scaffolding!("calc");


### PR DESCRIPTION
This revision includes:
- Generating Rust scaffolding code
  - Add uniffi-related crates as dependencies
  - Create build file for uniffi_build
  - Add code to include generated scaffolding code